### PR TITLE
Fixed Heroku timeout error R10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "A boilerplate for web APIs using Node",
   "main": "index.js",
   "private": true,
-  "engines": {
-    "node": ">=7.6.0"
-  },
   "scripts": {
     "start": "node cluster.js",
     "dev": "cross-env NODE_PATH=. NODE_ENV=development nodemon",


### PR DESCRIPTION
**Error** :
Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch

**Fix**:
Remove engines in package.json.

**[Further info](https://github.com/keystonejs/keystone-classic/issues/3994#issuecomment-280639251)**.